### PR TITLE
module files placed in install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,10 @@ list ( APPEND geokdtree_files
 	kdtree.f90
 )
 
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
+endif()
+
 ################################################################################
 # Library
 ################################################################################


### PR DESCRIPTION
fortran module files were not placed correctly when doing a `make install`